### PR TITLE
Add support for the ‘running average’ SG encoding method

### DIFF
--- a/Source/Probulator/ExperimentSG.h
+++ b/Source/Probulator/ExperimentSG.h
@@ -26,6 +26,12 @@ public:
         m_ambientLobeEnabled = state;
         return *this;
     }
+    
+    ExperimentSGBase& setNonNegativeSolve(bool state)
+    {
+        m_nonNegativeSolve = state;
+        return *this;
+    }
 
     void run(SharedData& data) override
     {
@@ -44,10 +50,11 @@ public:
 		outProperties.push_back(Property("BRDF Lambda", &m_brdfLambda));
 	}
 
+    bool m_nonNegativeSolve = false;
     bool m_ambientLobeEnabled = false;
     u32 m_lobeCount = 1;
     float m_lambda = 0.0f;
-    float m_brdfLambda = 0.0f;
+    float m_brdfLambda = 0.0f; // 0 to use a curve fit for irradiance.
     SgBasis m_lobes;
 
 protected:
@@ -94,14 +101,31 @@ protected:
         SphericalGaussian brdf;
         brdf.lambda = m_brdfLambda;
         brdf.mu = vec3(sgFindMu(brdf.lambda, pi));
-
+        
         m_irradianceImage = Image(data.m_outputSize);
-        m_irradianceImage.forPixels2D([&](vec4& pixel, ivec2 pixelPos)
+        
+        // If the BRDF lambda is greater than 0, use a SG for the BRDF.
+        // Otherwise, use a curve fit.
+        if (m_brdfLambda > 0.f)
         {
-            brdf.p = data.m_directionImage.at(pixelPos);
-            vec3 sampleSg = sgBasisDot(m_lobes, brdf) / pi;
-            pixel = vec4(sampleSg, 1.0f);
-        });
+            m_irradianceImage.forPixels2D([&](vec4& pixel, ivec2 pixelPos)
+                                          {
+                                              brdf.p = data.m_directionImage.at(pixelPos);
+                                              vec3 sampleSg = sgBasisDot(m_lobes, brdf) / pi;
+                                              pixel = vec4(sampleSg, 1.0f);
+                                          });
+        }
+        else
+        {
+            m_irradianceImage.forPixels2D([&](vec4& pixel, ivec2 pixelPos)
+                                          {
+                                              vec3 normal = data.m_directionImage.at(pixelPos);
+                                              vec3 sampleSg = sgBasisIrradianceFitted(m_lobes, normal);
+                                              pixel = vec4(sampleSg, 1.0f);
+                                          });
+        }
+        
+       
     }
 };
 
@@ -122,6 +146,75 @@ public:
                 const SphericalGaussian& sg = m_lobes[lobeIt];
                 float w = sgEvaluate(sg.p, sg.lambda, sample.direction);
                 m_lobes[lobeIt].mu += sample.value * normFactor * (w / sampleCount);
+            }
+        }
+    }
+};
+  
+// A progressive least-squares solve. Reference: http://torust.me/rendering/irradiance-caching/spherical-gaussians/2018/09/21/spherical-gaussians.html
+class ExperimentSGRunningAverage : public ExperimentSGBase
+{
+public:
+    
+    void solveForRadiance(const std::vector<RadianceSample>& radianceSamples) override
+    {
+        const u32 lobeCount = (u32)m_lobes.size();
+
+        float lobeMCSphericalIntegrals[lobeCount];
+
+        for (u32 lobeIt = 0; lobeIt < lobeCount; ++lobeIt) {
+            lobeMCSphericalIntegrals[lobeIt] = 0.f;
+        }
+
+        float lobePrecomputedSphericalIntegrals[lobeCount];
+        for (u64 lobeIt = 0; lobeIt < lobeCount; ++lobeIt)
+        {
+            lobePrecomputedSphericalIntegrals[lobeIt] = (1.f - exp(-4.f * m_lobes[lobeIt].lambda)) / (4 * m_lobes[lobeIt].lambda);
+        }
+
+        float totalSampleWeight = 0.f;
+        
+        for (const RadianceSample& sample : radianceSamples) {
+            const float sampleWeight = 1.f;
+            totalSampleWeight += sampleWeight;
+            float sampleWeightScale = sampleWeight / totalSampleWeight;
+
+            vec3 currentEstimate = vec3(0.f);
+
+            float sampleLobeWeights[lobeCount];
+            for (u32 lobeIt = 0; lobeIt < lobeCount; ++lobeIt) {
+                float dotProduct = dot(m_lobes[lobeIt].p, sample.direction);
+                float weight = exp(m_lobes[lobeIt].lambda * (dotProduct - 1.0));
+                currentEstimate += m_lobes[lobeIt].mu * weight;
+
+                sampleLobeWeights[lobeIt] = weight;
+            }
+
+            for (u32 lobeIt = 0; lobeIt < lobeCount; ++lobeIt) {
+                float weight = sampleLobeWeights[lobeIt];
+                if (weight == 0.f) { continue; }
+
+                float sphericalIntegralGuess = weight * weight;
+                
+                // Update the MC-computed integral of the lobe over the domain.
+                lobeMCSphericalIntegrals[lobeIt] += (sphericalIntegralGuess - lobeMCSphericalIntegrals[lobeIt]) * sampleWeightScale;
+                
+                // The most accurate method requires using the MC-computed integral,
+                // since then bias in the estimate will partially cancel out.
+                // However, if you don't want to store a weight per-lobe you can instead substitute it with the
+                // precomputed integral at a slight increase in error.
+                
+                // Clamp the MC-computed integral to within a reasonable ad-hoc factor of the actual integral to avoid noise.
+                float sphericalIntegral = max(lobeMCSphericalIntegrals[lobeIt], lobePrecomputedSphericalIntegrals[lobeIt] * 0.75f);
+                
+                vec3 otherLobesContribution = currentEstimate - m_lobes[lobeIt].mu * weight;
+                vec3 newValue = (sample.value - otherLobesContribution) * weight / sphericalIntegral;
+                
+                m_lobes[lobeIt].mu += (newValue - m_lobes[lobeIt].mu) * sampleWeightScale;
+
+                if (m_nonNegativeSolve) {
+                    m_lobes[lobeIt].mu = max(m_lobes[lobeIt].mu, vec3(0.f));
+                }
             }
         }
     }

--- a/Source/Probulator/Experiments.cpp
+++ b/Source/Probulator/Experiments.cpp
@@ -69,21 +69,25 @@ void addAllExperiments(ExperimentList& experiments)
         .setLobeCountAndLambda(lobeCount, lambda);
 
     addExperiment<ExperimentSGLS>(experiments, "Spherical Gaussians [Least Squares]", "SGLS")
-        .setBrdfLambda(3.0f) // Chosen arbitrarily through experimentation
         .setLobeCountAndLambda(lobeCount, lambda);
 
     addExperiment<ExperimentSGLS>(experiments, "Spherical Gaussians [Least Squares + Ambient]", "SGLSA")
-        .setBrdfLambda(3.0f) // Chosen arbitrarily through experimentation
         .setAmbientLobeEnabled(true)
+        .setBrdfLambda(3.0f) // Chosen arbitrarily through experimentation
         .setLobeCountAndLambda(lobeCount, lambda);
 
     addExperiment<ExperimentSGNNLS>(experiments, "Spherical Gaussians [Non-Negative Least Squares]", "SGNNLS")
-        .setBrdfLambda(3.0f) // Chosen arbitrarily through experimentation
         .setLobeCountAndLambda(lobeCount, lambda);
+    
+    addExperiment<ExperimentSGRunningAverage>(experiments, "Spherical Gaussians [Running Average]", "SGRA")
+        .setLobeCountAndLambda(lobeCount, lambda);
+    
+    addExperiment<ExperimentSGRunningAverage>(experiments, "Spherical Gaussians [Non-Negative Running Average]", "SGNNRA")
+        .setLobeCountAndLambda(lobeCount, lambda)
+        .setNonNegativeSolve(true);
 
     addExperiment<ExperimentSGGA>(experiments, "Spherical Gaussians [Genetic Algorithm]", "SGGA")
         .setPopulationAndGenerationCount(50, 2000)
-        .setBrdfLambda(3.0f) // Chosen arbitrarily through experimentation
         .setLobeCountAndLambda(lobeCount, lambda)
         .setEnabled(false); // disabled by default, as it requires *very* long time to converge
 }

--- a/Source/Probulator/Experiments.h
+++ b/Source/Probulator/Experiments.h
@@ -63,7 +63,7 @@ public:
             samples.reserve(sampleCount);
             for (u32 sampleIt = 0; sampleIt < sampleCount; ++sampleIt)
             {
-                vec2 sampleUv = sampleHammersley(sampleIt, sampleCount);
+                vec2 sampleUv = vec2(sampleHalton(sampleIt + 1, 2), sampleHalton(sampleIt + 1, 3));
                 vec3 direction = m_basis * sampleUniformSphere(sampleUv);
 
                 vec3 sample = (vec3)image.sampleNearest(cartesianToLatLongTexcoord(direction));

--- a/Source/Probulator/Math.h
+++ b/Source/Probulator/Math.h
@@ -173,6 +173,19 @@ namespace Probulator
 		float vdc = float(bits) * 2.3283064365386963e-10f;
 		return vec2(float(i) / float(n), vdc);
 	}
+    
+    inline float sampleHalton(u32 index, u32 base)
+    {
+        float f = 1.f;
+        float r = 0.f;
+        
+        while (index > 0) {
+            f = f / float(base);
+            r += f * float(index % base);
+            index /= base;
+        }
+        return r;
+    }
 
 	inline vec3 sampleUniformHemisphere(float u, float v)
 	{

--- a/Source/Probulator/SGBasis.cpp
+++ b/Source/Probulator/SGBasis.cpp
@@ -72,5 +72,16 @@ namespace Probulator
 	{
 		return dot(sgBasisMeanSquareError(basis, radianceSamples), vec3(1.0f / 3.0f));
 	}
+    
+    // Stephen Hill [2016], https://mynameismjp.wordpress.com/2016/10/09/sg-series-part-3-diffuse-lighting-from-an-sg-light-source/
+    vec3 sgBasisIrradianceFitted(const SgBasis& basis, const vec3& normal)
+    {
+        vec3 result = vec3(0.0f);
+        for (const SphericalGaussian& basisLobe : basis)
+        {
+            result += sgIrradianceFitted(basisLobe, normal);
+        }
+        return result / pi;
+    }
 
 }

--- a/Source/Probulator/SGBasis.h
+++ b/Source/Probulator/SGBasis.h
@@ -15,4 +15,5 @@ namespace Probulator
 	void sgBasisMeanAndVariance(const SphericalGaussian* lobes, u32 lobeCount, u32 sampleCount, vec3& outMean, vec3& outVariance);
 	vec3 sgBasisMeanSquareError(const SgBasis& basis, const std::vector<RadianceSample>& radianceSamples);
 	float sgBasisMeanSquareErrorScalar(const SgBasis& basis, const std::vector<RadianceSample>& radianceSamples);
+    vec3 sgBasisIrradianceFitted(const SgBasis& basis, const vec3& normal);
 }

--- a/Source/Probulator/SphericalGaussian.cpp
+++ b/Source/Probulator/SphericalGaussian.cpp
@@ -51,4 +51,37 @@ namespace Probulator
 		return sgFindMu(targetLambda, targetIntegral);
 	}
 
+    // Stephen Hill [2016], https://mynameismjp.wordpress.com/2016/10/09/sg-series-part-3-diffuse-lighting-from-an-sg-light-source/
+    vec3 sgIrradianceFitted(const SphericalGaussian& lightingLobe, const vec3& normal)
+    {
+        if(lightingLobe.lambda == 0.f)
+            return lightingLobe.mu;
+        
+        const float muDotN = dot(lightingLobe.p, normal);
+        const float lambda = lightingLobe.lambda;
+        
+        const float c0 = 0.36f;
+        const float c1 = 1.0f / (4.0f * c0);
+        
+        float eml  = exp(-lambda);
+        float em2l = eml * eml;
+        float rl   = 1.f / lambda;
+        
+        float scale = 1.0f + 2.0f * em2l - rl;
+        float bias  = (eml - em2l) * rl - em2l;
+        
+        float x  = sqrt(1.0f - scale);
+        float x0 = c0 * muDotN;
+        float x1 = c1 * x;
+        
+        float n = x0 + x1;
+        
+        float y = saturate(muDotN);
+        if(abs(x0) <= x1)
+            y = n * n / x;
+        
+        float result = scale * y + bias;
+        
+        return result * lightingLobe.mu * sgIntegral(lightingLobe.lambda);
+    }
 }

--- a/Source/Probulator/SphericalGaussian.h
+++ b/Source/Probulator/SphericalGaussian.h
@@ -44,4 +44,6 @@ namespace Probulator
 	// Find SG mu for a given lambda to match total energy of another SG
 	float sgFindMu(float targetLambda, float lambda, float mu);
 
+    // Approximate SG irradiance using a curve fit.
+    vec3 sgIrradianceFitted(const SphericalGaussian& lightingLobe, const vec3& normal);
 }


### PR DESCRIPTION
Implement the progressive running average encoding method as described in http://torust.me/rendering/irradiance-caching/spherical-gaussians/2018/09/21/spherical-gaussians.html.

Also, switch over to using Stephen Hill's curve fit for irradiance where beneficial (everything apart from the naïve projection and SGs with an ambient lobe), and generate radiance samples according to the Halton rather than Hammersley distribution.