### PR TITLE
L3 SH: fix incorrect scale factors for M+/- 1.

### DIFF
--- a/Source/Probulator/SphericalHarmonics.h
+++ b/Source/Probulator/SphericalHarmonics.h
@@ -100,9 +100,9 @@ namespace Probulator
 		{
 			result[i++] = -sqrt( 70.0f/(64.0f*pi))*y*(3.0f*x2-y2);
 			result[i++] =  sqrt(105.0f/ (4.0f*pi))*y*x*z;
-			result[i++] = -sqrt( 21.0f/(16.0f*pi))*y*(-1.0f+5.0f*z2);
+			result[i++] = -sqrt( 21.0f/(32.0f*pi))*y*(-1.0f+5.0f*z2);
 			result[i++] =  sqrt(  7.0f/(16.0f*pi))*(5.0f*z3-3.0f*z);
-			result[i++] = -sqrt( 21.0f/(64.0f*pi))*x*(-1.0f+5.0f*z2);
+			result[i++] = -sqrt( 21.0f/(32.0f*pi))*x*(-1.0f+5.0f*z2);
 			result[i++] =  sqrt(105.0f/(16.0f*pi))*(x2-y2)*z;
 			result[i++] = -sqrt( 70.0f/(64.0f*pi))*x*(x2-3.0f*y2);			
 		}


### PR DESCRIPTION
The L3 M+/-1 coefficients had incorrect scale factors, which was found by computing the spherical Gram matrix; see https://en.wikipedia.org/wiki/Table_of_spherical_harmonics for the reference.